### PR TITLE
Hashrate calculation feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .vscode/
+Cargo.lock

--- a/src/hashrate.rs
+++ b/src/hashrate.rs
@@ -1,6 +1,22 @@
 use std::time::{Duration, Instant};
 use colored::*;
 
+
+pub fn get_unit(hashrate: f32) -> (f32, String) {
+    let mut hashrate = hashrate as f32;
+    let mut unit = "";
+    let units = vec!["k", "M", "G", "T", "P", "E", "Z", "Y"];
+    for u in units.iter() {
+        if hashrate > 1000.0 {
+            hashrate /= 1000.0;
+            unit = u;
+        } else {
+            break;
+        }
+    }
+    (hashrate, format!("{}H/s", unit))
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Hashrate {
     pub worker_id: u32,
@@ -14,9 +30,11 @@ pub struct Hashrate {
 
 impl std::fmt::Display for Hashrate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Worker {} Hashrate = {} H/s",
+        let (value, unit) = get_unit(self.value);
+        write!(f, "Worker {} Hashrate = {} {}",
                format!("#{}", self.worker_id).yellow(),
-               format!("{:.3}", self.value).red())
+               format!("{:.3}", value).red(),
+               unit)
     }
 }
 

--- a/src/hashrate.rs
+++ b/src/hashrate.rs
@@ -1,0 +1,56 @@
+use std::time::{Duration, Instant};
+use colored::*;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Hashrate {
+    pub worker_id: u32,
+    value: f32,
+    counter: u32,
+    counter_max: u32,
+    sampling_start: Instant,
+    report_start: Instant,
+    report_interval: Duration,
+}
+
+impl std::fmt::Display for Hashrate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Worker {} Hashrate = {} H/s",
+               format!("#{}", self.worker_id).yellow(),
+               format!("{:.3}", self.value).red())
+    }
+}
+
+impl core::iter::Sum for Hashrate {
+    fn sum<I: Iterator<Item=Hashrate>>(iter: I) -> Hashrate {
+        iter.fold(Hashrate::new(0, 0.0), |a, b| Hashrate::new(0, a.value + b.value))
+    }
+}
+
+impl Hashrate {
+    pub fn new(worker_id: u32, value: f32) -> Self {
+        Self { worker_id, value, counter: 0, 
+               counter_max: 32,
+               sampling_start: Instant::now(),
+               report_start: Instant::now(),
+               report_interval: Duration::from_secs(60)}
+    }
+    pub fn value(&self) -> f32 {
+        self.value
+    }
+    pub fn available(&self) -> bool {
+        self.report_start.elapsed() > self.report_interval
+    }
+    pub fn count(&mut self) {
+        self.counter += 1;
+        // Every counter_max hashes, calculate the hashrate and reset the timer.
+        if self.counter >= self.counter_max {
+            let duration: f32 = self.sampling_start.elapsed()
+                .as_millis() as f32;
+            let duration: f32 = duration/ 1_000.0;
+            let hashrate: f32 = self.counter as f32 / duration;
+            self.value = (self.value + hashrate) / 2.0;
+            self.sampling_start = Instant::now();
+            self.counter = 0;
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,28 +150,25 @@ fn main() {
         let opt = opt.clone();
         thread::spawn(move || {
             let mut _start = Instant::now();
-            let mut v2: Vec<Option<Hashrate>> = vec![None; opt.threads];
-            println!("{}", v2.len());
+            let mut v: Vec<Option<Hashrate>> = vec![None; opt.threads];
             for sol in sol_recv {
                 if opt.hashrate > 0 {
-                    // let nworkers = ctx.lock().unwrap().workers.len();
                     let duration: Duration = _start.elapsed();
-                    v2[sol.hashrate.worker_id as usize] = Some(sol.hashrate.borrow().clone());
-                    if ! v2.contains(&None) && duration.as_secs_f32() > 30.0 {
-                        if opt.hashrate > 1 {
-                            for h in v2.iter() {
-                                println!("{}", h.borrow().clone().unwrap());
-                            }
-                        }
+                    v[sol.hashrate.worker_id as usize] = Some(sol.hashrate.borrow().clone());
+                    if ! v.contains(&None) && duration.as_secs_f32() > 30.0 {
                         let mut total: f32 = 0.0;
-                        for h in v2.iter() {
-                            total += h.as_ref().unwrap().value();
+                        for h in v.iter() {
+                            let h2 = h.as_ref().unwrap();
+                            if opt.hashrate > 1 {
+                                println!("{}", h2);
+                            }
+                            total += h2.value();
                         }
                         println!("{} = {} {} ({})",
                                  "Total Hashrate".blue(),
                                  format!("{:.3}", total).red(),
                                  "H/s",
-                                 format!("{} Workers", v2.len()).yellow());
+                                 format!("{} Workers", v.len()).yellow());
                         _start = Instant::now();
                     }
                 }

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
 use thiserror::Error;
-use std::time::{Duration, Instant};
+use crate::hashrate::Hashrate;
 
 #[derive(Error, Debug)]
 pub enum WorkerError {
@@ -22,8 +22,7 @@ pub enum WorkerError {
 pub struct Solution {
     pub id: u32,
     pub found: bool,
-    pub worker_id: u32,
-    pub hashrate: f32,
+    pub hashrate: Hashrate,
     pub nonce: Vec<u8>,
 }
 
@@ -94,8 +93,6 @@ impl Worker {
                     }
                 };
 
-                let mut hashrate: f32 = 0.0;
-
                 let mut counter = 0;
 
                 let mut hasher = Hasher::new(Arc::clone(&puzzle.context));
@@ -105,41 +102,28 @@ impl Worker {
                 rng.fill_bytes(&mut puzzle.blob[b..e]);
                 hasher.hash_first(&puzzle.blob);
 
-                let mut _start = Instant::now();
+                let mut hr: Hashrate = Hashrate::new(worker_id, 0.0);
                 loop {
                     let prev_nonce = puzzle.blob[b..e].to_vec();
 
                     rng.fill_bytes(&mut puzzle.blob[b..e]);
                     let out = hasher.hash_next(&puzzle.blob);
 
-                    if out.meets_difficulty(puzzle.target) {
+                    let found = out.meets_difficulty(puzzle.target);
+                    if found || hr.available() {
                         callback.send(Solution {
                             id: puzzle.id,
-                            found: true,
-                            worker_id: worker_id,
-                            hashrate: hashrate,
+                            found: found,
+                            hashrate: Hashrate::new(worker_id, hr.value()),
                             nonce: prev_nonce,
                         })?;
-                    } else {
-                        if hashrate > 0.0 {
-                            callback.send(Solution {
-                                id: puzzle.id,
-                                found: false,
-                                worker_id: worker_id,
-                                hashrate: hashrate,
-                                nonce: prev_nonce,
-                            })?;
-                        }
                     }
                     counter += 1;
+                    hr.count();
 
                     // Every 512 hashes, if there is a new message, cancel the current
                     // puzzle and process the message.
                     if counter >= 512 {
-                        let duration: Duration = _start.elapsed();
-                        let duration: f32 = duration.as_millis() as f32/ 1_000.0;
-                        hashrate = counter as f32 / duration;
-                        _start = Instant::now();
                         if let Ok(new_msg) = msg_recv.try_recv() {
                             msg = new_msg;
                             break;


### PR DESCRIPTION
Added hash rate calculation feature.

* Created `hashrate.rs` file.
* Created another channel for hashrate.
* Added `hashrate` option to command line parameters (default = 1). If you set it `0`, hashrate will not be reported. If you set `1`, only total hash rate will be reported. If the value is higher than `1`, hash rate for each worker will be reported.